### PR TITLE
Fix page height for sub-panels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4569,5 +4569,5 @@ span.customSelect.changed {
 	top: 0;
 	left: 0;
 	width: 100%;
-	height: 100%;
+	height: calc(100% - 60px);
 }


### PR DESCRIPTION
The inner frame wasn't taking into account the top bar, and was cutting off the bottom section of pages. Adjusted so pages fit properly. Couchpotato, and transmission both have buttons at the bottom that got cut off previously.
