### PR TITLE
Fix for Home reload after saving settings.

### DIFF
--- a/savesettings.php
+++ b/savesettings.php
@@ -77,12 +77,8 @@ if($init)
     header("Location: index.php");
 }
 else {
-    echo "<!DOCTYPE html>";
-    echo "<head>";
-    echo "<title>Settings Saved</title>";
-    echo "<script type='text/javascript'>window.parent.location.reload()</script>";
-    echo "</head>";
-    echo "<body></body></html>";
+    header("Location: home.php");
+}
 }
 
 // update readme and screenshots


### PR DESCRIPTION
Changing the else condition to change the header back to home.php after saving settings resolves a constant reload (resend changes) issue.
